### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -31,4 +31,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
        name: NotCPUCores
-       path: C:\Program Files (x86)\AutoIt3\Aut2Exe\NotCPUCores\NotCPUCores.exe
+       path: C:\Program Files (x86)\AutoIt3\Aut2Exe\NotCPUCores\NotCPUCores.ex
+       if-no-files-found: error

--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -1,0 +1,34 @@
+name: ncc
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    steps:
+    - name: Install Autoit
+      run: |
+           Invoke-WebRequest -Uri https://www.autoitscript.com/cgi-bin/getfile.pl?autoit3/autoit-v3-setup.exe -OutFile autoit-v3-setup.exe
+           ./autoit-v3-setup.exe /S
+
+    - name: Checkout repo
+      run: |
+           cd C:\"Program Files (x86)"\AutoIt3\Aut2Exe
+           git clone https://github.com/rcmaehl/NotCPUCores --depth 1
+      
+    - name: Compile
+      run: |
+           cd C:\"Program Files (x86)"\AutoIt3
+           Move-Item Include Aut2Exe\NotCPUCores
+           cd Aut2Exe
+           Move-Item aut2exe.exe NotCPUCores
+           cd NotCPUCores
+           ./Aut2exe.exe /in NotCPUCores.au3 /out NotCPUCores.exe /comp 4
+
+
+    - name: Upload
+      uses: actions/upload-artifact@v2
+      with:
+       name: NotCPUCores
+       path: C:\Program Files (x86)\AutoIt3\Aut2Exe\NotCPUCores\NotCPUCores.exe

--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -31,5 +31,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
        name: NotCPUCores
-       path: C:\Program Files (x86)\AutoIt3\Aut2Exe\NotCPUCores\NotCPUCores.ex
+       path: C:\Program Files (x86)\AutoIt3\Aut2Exe\NotCPUCores\NotCPUCores.exe
        if-no-files-found: error

--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -24,7 +24,7 @@ jobs:
            cd Aut2Exe
            Move-Item aut2exe.exe NotCPUCores
            cd NotCPUCores
-           ./Aut2exe.exe /in NotCPUCores.au3 /out NotCPUCores.exe /comp 4 /no pack /icon icon.ico
+           ./Aut2exe.exe /in NotCPUCores.au3 /out NotCPUCores.exe /comp 4 /nopack /icon icon.ico
 
 
     - name: Upload

--- a/.github/workflows/ncc.yml
+++ b/.github/workflows/ncc.yml
@@ -24,7 +24,7 @@ jobs:
            cd Aut2Exe
            Move-Item aut2exe.exe NotCPUCores
            cd NotCPUCores
-           ./Aut2exe.exe /in NotCPUCores.au3 /out NotCPUCores.exe /comp 4
+           ./Aut2exe.exe /in NotCPUCores.au3 /out NotCPUCores.exe /comp 4 /no pack /icon icon.ico
 
 
     - name: Upload


### PR DESCRIPTION
This pr adds CI which generates NotCPUCores.exe which can be downloaded from actions tab.

Additionally a badge can be added to readme to show that it "passes build"

After merging  it would be https://img.shields.io/github/workflow/status/rcmaehl/NotCPUCores/ncc

This is just #75 but updated to download Autoit in CI instead of hosting files in this repo