### PR TITLE
Fix 64 bit file name

### DIFF
--- a/installer.nsi
+++ b/installer.nsi
@@ -123,9 +123,9 @@ ${EndIf}
 
 ; Select file to be installed
 ${If} ${RunningX64}
-  File "/oname=${PRODUCT_NAME}.exe" ${PRODUCT_NAME}_x64.exe
+  File "/oname=${PRODUCT_NAME}.exe" ${PRODUCT_NAME}.exe
   ${If} ${DEBUGGING_ENABLED} == 1
-    MessageBox MB_OK "File that is used: ${PRODUCT_NAME}_x64.exe"
+    MessageBox MB_OK "File that is used: ${PRODUCT_NAME}.exe"
   ${EndIf}
 ${Else}
   File "/oname=${PRODUCT_NAME}.exe" ${PRODUCT_NAME}_x86.exe


### PR DESCRIPTION
When compiling the 64 bit executable is just "NotCPUCores.exe" So this pr makes the installer script work out of the box without need to change name.